### PR TITLE
Vagga should not run as root

### DIFF
--- a/lib/vagrant-vagga/command.rb
+++ b/lib/vagrant-vagga/command.rb
@@ -11,8 +11,6 @@ module VagrantPlugins
       def execute
         args = @argv.join(' ')
         vagga_command = "vagga #{args}"
-        # Workaround for ERROR:vagga::wrapper: Error executing _build: Error symlinking storage: Permission denied (os error 13)
-        vagga_command = "sudo #{vagga_command}"
         command = "cd /vagrant; #{vagga_command}"
 
         with_target_vms(nil, single_target: true) do |vm|


### PR DESCRIPTION
Per #1 `vagga` should not run as root.  The previous work-a-round which
required vagga to execute with `sudo` no longer appears to be an issue.
